### PR TITLE
feat: add splash screen and auth view model with navigation logic

### DIFF
--- a/app/src/main/java/com/almalaundry/shared/commons/Application.kt
+++ b/app/src/main/java/com/almalaundry/shared/commons/Application.kt
@@ -3,19 +3,57 @@ package com.almalaundry.shared.commons
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
+import com.almalaundry.featured.auth.commons.AuthRoutes
+import com.almalaundry.featured.home.commons.HomeRoutes
 import com.almalaundry.shared.commons.compositional.LocalNavController
+import com.almalaundry.shared.presentation.screen.SplashScreen
+import com.almalaundry.shared.presentation.state.SplashState
 import com.almalaundry.shared.presentation.ui.theme.AlmaLaundryTheme
+import com.almalaundry.shared.presentation.viewmodels.AuthViewModel
+import kotlinx.coroutines.delay
 
 @Composable
 fun Application() {
     AlmaLaundryTheme {
         Surface {
             val navController = rememberNavController()
-            CompositionLocalProvider(LocalNavController provides navController) {
-                ApplicationNavigationGraph(
-                    navController = navController
-                )
+            val authViewModel = hiltViewModel<AuthViewModel>()
+            var splashState by remember { mutableStateOf<SplashState>(SplashState.Loading) }
+
+            LaunchedEffect(Unit) {
+                val session = authViewModel.sessionManager.getSession()
+                delay(1000)
+                splashState = if (session != null) {
+                    SplashState.NavigateToDashboard
+                } else {
+                    SplashState.NavigateToLogin
+                }
+            }
+
+            when (splashState) {
+                SplashState.Loading -> SplashScreen()
+                is SplashState.NavigateToDashboard -> {
+                    CompositionLocalProvider(LocalNavController provides navController) {
+                        ApplicationNavigationGraph(
+                            navController = navController, startDestination = HomeRoutes.Index.route
+                        )
+                    }
+                }
+
+                is SplashState.NavigateToLogin -> {
+                    CompositionLocalProvider(LocalNavController provides navController) {
+                        ApplicationNavigationGraph(
+                            navController = navController, startDestination = AuthRoutes.Login.route
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/almalaundry/shared/commons/ApplicationNavigationGraph.kt
+++ b/app/src/main/java/com/almalaundry/shared/commons/ApplicationNavigationGraph.kt
@@ -5,82 +5,53 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import com.almalaundry.featured.auth.commons.AuthRoutes
 import com.almalaundry.featured.auth.commons.authNavigation
-import com.almalaundry.featured.home.commons.HomeRoutes
 import com.almalaundry.featured.home.commons.homeNavigation
 import com.almalaundry.featured.order.commons.orderNavigation
 import com.almalaundry.featured.profile.commons.profileNavigation
-import com.almalaundry.shared.commons.session.SessionManager
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 
 @Composable
 fun ApplicationNavigationGraph(
-    navController: NavHostController, modifier: Modifier = Modifier
+    navController: NavHostController,
+    startDestination: String,
+    modifier: Modifier = Modifier
 ) {
-    val authViewModel = hiltViewModel<AuthViewModel>()
-    var isLoading by remember { mutableStateOf(true) }
-    var startDestination by remember { mutableStateOf(AuthRoutes.Login.route) }
-
-    LaunchedEffect(Unit) {
-        val session = authViewModel.sessionManager.getSession()
-        startDestination = if (session != null) HomeRoutes.Index.route else AuthRoutes.Login.route
-        isLoading = false
-    }
-
-    if (isLoading) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator()
+    NavHost(
+        navController = navController,
+        startDestination = startDestination,
+        modifier = modifier,
+        enterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { it },
+                animationSpec = tween(durationMillis = 300)
+            ) + fadeIn(animationSpec = tween(300))
+        },
+        popEnterTransition = {
+            slideInHorizontally(
+                initialOffsetX = { -it },
+                animationSpec = tween(durationMillis = 300)
+            ) + fadeIn(animationSpec = tween(300))
+        },
+        exitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { -it },
+                animationSpec = tween(durationMillis = 300)
+            ) + fadeOut(animationSpec = tween(300))
+        },
+        popExitTransition = {
+            slideOutHorizontally(
+                targetOffsetX = { it },
+                animationSpec = tween(durationMillis = 300)
+            ) + fadeOut(animationSpec = tween(300))
         }
-    } else {
-        NavHost(navController = navController,
-            startDestination = startDestination,
-            modifier = modifier,
-            enterTransition = {
-                slideInHorizontally(
-                    initialOffsetX = { it }, animationSpec = tween(durationMillis = 300)
-                ) + fadeIn(animationSpec = tween(300))
-            },
-            popEnterTransition = {
-                slideInHorizontally(
-                    initialOffsetX = { -it }, animationSpec = tween(durationMillis = 300)
-                ) + fadeIn(animationSpec = tween(300))
-            },
-            exitTransition = {
-                slideOutHorizontally(
-                    targetOffsetX = { -it }, animationSpec = tween(durationMillis = 300)
-                ) + fadeOut(animationSpec = tween(300))
-            },
-            popExitTransition = {
-                slideOutHorizontally(
-                    targetOffsetX = { it }, animationSpec = tween(durationMillis = 300)
-                ) + fadeOut(animationSpec = tween(300))
-            }) {
-            authNavigation()
-            homeNavigation()
-            orderNavigation()
-            profileNavigation()
-        }
+    ) {
+        authNavigation()
+        homeNavigation()
+        orderNavigation()
+        profileNavigation()
     }
 }
-
-@HiltViewModel
-class AuthViewModel @Inject constructor(
-    val sessionManager: SessionManager
-) : ViewModel()

--- a/app/src/main/java/com/almalaundry/shared/presentation/screen/SplashScreen.kt
+++ b/app/src/main/java/com/almalaundry/shared/presentation/screen/SplashScreen.kt
@@ -1,0 +1,72 @@
+package com.almalaundry.shared.presentation.screen
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Store
+
+@Composable
+fun SplashScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        // Animasi scale dengan spring untuk efek overshoot
+        val scale by animateFloatAsState(
+            targetValue = 1f, animationSpec = spring(
+                dampingRatio = 0.5f,
+                stiffness = 100f
+            ), label = "SplashScale"
+        )
+        // Animasi fade dengan tween
+        val alpha by animateFloatAsState(
+            targetValue = 1f, animationSpec = tween(durationMillis = 1000), label = "SplashFade"
+        )
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .scale(scale)
+                .alpha(alpha)
+        ) {
+            Icon(
+                imageVector = Lucide.Store,
+                contentDescription = "Almada Laundry Logo",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .size(120.dp)
+                    .padding(bottom = 16.dp)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Almada Laundry", style = MaterialTheme.typography.headlineMedium.copy(
+                    fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/almalaundry/shared/presentation/state/SplashState.kt
+++ b/app/src/main/java/com/almalaundry/shared/presentation/state/SplashState.kt
@@ -1,0 +1,7 @@
+package com.almalaundry.shared.presentation.state
+
+sealed class SplashState {
+    data object Loading : SplashState()
+    data object NavigateToDashboard : SplashState()
+    data object NavigateToLogin : SplashState()
+}

--- a/app/src/main/java/com/almalaundry/shared/presentation/viewmodels/AuthViewModel.kt
+++ b/app/src/main/java/com/almalaundry/shared/presentation/viewmodels/AuthViewModel.kt
@@ -1,0 +1,11 @@
+package com.almalaundry.shared.presentation.viewmodels
+
+import androidx.lifecycle.ViewModel
+import com.almalaundry.shared.commons.session.SessionManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    val sessionManager: SessionManager
+) : ViewModel()


### PR DESCRIPTION
This commit introduces a splash screen that displays briefly upon application launch. It also adds an authentication view model (`AuthViewModel`) to manage user session data. The navigation graph logic is updated to conditionally navigate to either the login or home screen based on the user's session status. The splash state is managed with `SplashState` and includes states for `Loading`, `NavigateToDashboard`, and `NavigateToLogin`. A `SplashScreen` composable is added, which features a scaling and fading animation for the logo.